### PR TITLE
Fixed an ProjectDollhouse spritefont issue

### DIFF
--- a/TSOClient/tso.client/Content/Fonts/ProjectDollhouse_10px.spritefont
+++ b/TSOClient/tso.client/Content/Fonts/ProjectDollhouse_10px.spritefont
@@ -12,7 +12,7 @@ with.
     Modify this string to change the font that will be imported.
     SimDialogue - uni - game
     -->
-    <FontName>..\Content\Fonts\ProjectDollhouse.otf</FontName>
+    <FontName>ProjectDollhouse.otf</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change

--- a/TSOClient/tso.client/Content/Fonts/ProjectDollhouse_12px.spritefont
+++ b/TSOClient/tso.client/Content/Fonts/ProjectDollhouse_12px.spritefont
@@ -13,7 +13,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>..\Content\Fonts\ProjectDollhouse.otf</FontName>
+    <FontName>ProjectDollhouse.otf</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change

--- a/TSOClient/tso.client/Content/Fonts/ProjectDollhouse_14px.spritefont
+++ b/TSOClient/tso.client/Content/Fonts/ProjectDollhouse_14px.spritefont
@@ -11,7 +11,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>..\Content\Fonts\ProjectDollhouse.otf</FontName>
+    <FontName>ProjectDollhouse.otf</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change

--- a/TSOClient/tso.client/Content/Fonts/ProjectDollhouse_16px.spritefont
+++ b/TSOClient/tso.client/Content/Fonts/ProjectDollhouse_16px.spritefont
@@ -11,7 +11,7 @@ with.
     <!--
     Modify this string to change the font that will be imported.
     -->
-    <FontName>..\Content\Fonts\ProjectDollhouse.otf</FontName>
+    <FontName>ProjectDollhouse.otf</FontName>
 
     <!--
     Size is a float value, measured in points. Modify this value to change


### PR DESCRIPTION
For some reason the previous ProjectDollhouse spritefonts were pointing
eslewhere, despite the fact that the font was right there.